### PR TITLE
bugfixing for Debian/Ubuntu deploys

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,24 +23,23 @@ Example Playbook
 
 Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
 
-  - hosts: galera-db-servers
-    roles:
-      - common
-      - mariadb-galera
-    vars:
-          - galera_wsrep_cluster_name: galera-cluster-1
-          - galera_wsrep_cluster_address: "gcomm://{{ foo_IP }},{{ bar_IP }},{{ baz_IP }}"
-          - mariadb_conf_dir: "/etc/mysql/conf.d"
-          - galera_cluster_nodes: |
-                  - foo.domain
-                  - bar.domain
-                  - baz.domain
-          - galera_current_node_name: "{{ ansible_hostname }}.{{ vlan606_domain | join }}" # optional makes sense only if ansible_hostname is not in galera_cluster_nodes
-          - wsrep_node_address: "{{ node_IP }}" # optional makes sense only if it's not ansible_default_ipv4.address
-          - mariadb_install_xtrabackup: true  # optional
-          - mariadb_install_backupninja: true # optional
-          - ufw_enabled: false                # optional
-
+    - hosts: galera-db-servers
+      roles:
+        - common
+        - mariadb-galera
+      vars:
+            - galera_wsrep_cluster_name: galera-cluster-1
+            - galera_wsrep_cluster_address: "gcomm://{{ foo_IP }},{{ bar_IP }},{{ baz_IP }}"
+            - mariadb_conf_dir: "/etc/mysql/conf.d"
+            - galera_cluster_nodes: |
+                    - foo.domain
+                    - bar.domain
+                    - baz.domain
+            - galera_current_node_name: "{{ ansible_hostname }}.{{ vlan606_domain | join }}" # optional makes sense only if ansible_hostname is not in galera_cluster_nodes
+            - wsrep_node_address: "{{ node_IP }}" # optional makes sense only if it's not ansible_default_ipv4.address
+            - mariadb_install_xtrabackup: true  # optional
+            - mariadb_install_backupninja: true # optional
+            - ufw_enabled: false                # optional
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -23,9 +23,24 @@ Example Playbook
 
 Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
 
-    - hosts: servers
-      roles:
-         - { role: username.rolename, x: 42 }
+  - hosts: galera-db-servers
+    roles:
+      - common
+      - mariadb-galera
+    vars:
+          - galera_wsrep_cluster_name: galera-cluster-1
+          - galera_wsrep_cluster_address: "gcomm://{{ foo_IP }},{{ bar_IP }},{{ baz_IP }}"
+          - mariadb_conf_dir: "/etc/mysql/conf.d"
+          - galera_cluster_nodes: |
+                  - foo.domain
+                  - bar.domain
+                  - baz.domain
+          - galera_current_node_name: "{{ ansible_hostname }}.{{ vlan606_domain | join }}" # optional makes sense only if ansible_hostname is not in galera_cluster_nodes
+          - wsrep_node_address: "{{ node_IP }}" # optional makes sense only if it's not ansible_default_ipv4.address
+          - mariadb_install_xtrabackup: true  # optional
+          - mariadb_install_backupninja: true # optional
+          - ufw_enabled: false                # optional
+
 
 License
 -------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -66,6 +66,7 @@ mariadb_misc_config_files: |
     - { src: "mariadb@.service", dest: "/etc/systemd/system/mariadb@.service" }
     {%if mariadb_nrpe|bool %} - \{ src: "nrpe-mariadb.cfg.j2", dest: "/etc/nrpe.d/role-mariadb.cfg", owner: "nrpe", group: "nrpe", mode: "0440" \}{% endif %}
 
+mysql_std_path: /var/lib/mysql
 mysql_socket: /var/run/mysqld/mysqld.sock
 mysql_max_connections: 500
 mysql_max_user_connections: 200

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -81,7 +81,7 @@ mysql_collation_server: utf8_general_ci
 mysql_character_set_server: utf8
 mysql_wsrep_slave_threads: 4
 mariadb_galera_gcache_size: 250M
-mysql_wsrep_sst_method: xtrabackup
+mysql_wsrep_sst_method: rsync
 mysql_custom_vars: []
 #    - { section: ''          ,name: ''                         ,value: ''                       ,comment: '' }
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -55,3 +55,10 @@ mariadb_backup_root:            "/var/backups"
 mariadb_backup_compress:        "yes"
 mariadb_backup_databases:       "all"
 
+mariadb_apt_packages: |
+    - mariadb-server-{{mariadb_version}}
+    - mariadb-client-core-{{mariadb_version}}
+    - galera-3
+    {% if mariadb_install_xtrabackup|bool %}- percona-xtrabackup{% endif %} 
+    {% if mariadb_install_backupninja|bool %}- backupninja {% endif %}
+

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -63,8 +63,11 @@ mariadb_apt_packages: |
     {% if mariadb_install_backupninja|bool %}- backupninja {% endif %}
 
 mariadb_misc_config_files: |
-    - { src: "ssl.cnf.j2", dest: "{{mariadb_conf_dir}}/ssl", mode: "0644" }
-    - { src: "tuning.cnf.j2", dest: "{{mariadb_conf_dir}}/tuning.cnf", mode: "0644" }
     - { src: "mariadb@.service", dest: "/etc/systemd/system/mariadb@.service" }
     {%if mariadb_nrpe|bool %} - \{ src: "nrpe-mariadb.cfg.j2", dest: "/etc/nrpe.d/role-mariadb.cfg", owner: "nrpe", group: "nrpe", mode: "0440" \}{% endif %}
+
+mysql_collation_server: utf8_general_ci
+mysql_character_set_server: utf8
+mysql_custom_vars: []
+#    - { section: ''          ,name: ''                         ,value: ''                       ,comment: '' }
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -62,6 +62,13 @@ mariadb_apt_packages: |
     {% if mariadb_install_xtrabackup|bool %}- percona-xtrabackup{% endif %} 
     {% if mariadb_install_backupninja|bool %}- backupninja {% endif %}
 
+mariadb_yum_packages: |
+    - mariadb-server
+    - mariadb
+    - galera
+    {% if mariadb_install_xtrabackup|bool %}- percona-xtrabackup {% endif %}
+    {% if mariadb_install_backupninja|bool %}- backupninja {% endif %}
+
 mariadb_misc_config_files: |
     - { src: "mariadb@.service", dest: "/etc/systemd/system/mariadb@.service" }
     {%if mariadb_nrpe|bool %} - \{ src: "nrpe-mariadb.cfg.j2", dest: "/etc/nrpe.d/role-mariadb.cfg", owner: "nrpe", group: "nrpe", mode: "0440" \}{% endif %}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -66,6 +66,10 @@ mariadb_misc_config_files: |
     - { src: "mariadb@.service", dest: "/etc/systemd/system/mariadb@.service" }
     {%if mariadb_nrpe|bool %} - \{ src: "nrpe-mariadb.cfg.j2", dest: "/etc/nrpe.d/role-mariadb.cfg", owner: "nrpe", group: "nrpe", mode: "0440" \}{% endif %}
 
+galera_wsrep_cluster_address: gcomm://192.168.1.10,192.168.1.11,192.168.1.12
+galera_wsrep_cluster_name: mariadb-galera
+galera_wsrep_node_name: "{{ ansible_hostname }}"
+galera_wsrep_node_address: 192.168.1.10
 mysql_std_path: /var/lib/mysql
 mysql_socket: /var/run/mysqld/mysqld.sock
 mysql_max_connections: 500

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -66,7 +66,7 @@ mariadb_misc_config_files: |
     - { src: "mariadb@.service", dest: "/etc/systemd/system/mariadb@.service" }
     {%if mariadb_nrpe|bool %} - \{ src: "nrpe-mariadb.cfg.j2", dest: "/etc/nrpe.d/role-mariadb.cfg", owner: "nrpe", group: "nrpe", mode: "0440" \}{% endif %}
 
-mysql_socket: /var/run/mysqld/mysql.sock
+mysql_socket: /var/run/mysqld/mysqld.sock
 mysql_max_connections: 500
 mysql_max_user_connections: 200
 mysql_thread_cache_size: 500

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -62,3 +62,9 @@ mariadb_apt_packages: |
     {% if mariadb_install_xtrabackup|bool %}- percona-xtrabackup{% endif %} 
     {% if mariadb_install_backupninja|bool %}- backupninja {% endif %}
 
+mariadb_misc_config_files: |
+    - { src: "ssl.cnf.j2", dest: "{{mariadb_conf_dir}}/ssl", mode: "0644" }
+    - { src: "tuning.cnf.j2", dest: "{{mariadb_conf_dir}}/tuning.cnf", mode: "0644" }
+    - { src: "mariadb@.service", dest: "/etc/systemd/system/mariadb@.service" }
+    {%if mariadb_nrpe|bool %} - \{ src: "nrpe-mariadb.cfg.j2", dest: "/etc/nrpe.d/role-mariadb.cfg", owner: "nrpe", group: "nrpe", mode: "0440" \}{% endif %}
+

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -81,7 +81,7 @@ mysql_collation_server: utf8_general_ci
 mysql_character_set_server: utf8
 mysql_wsrep_slave_threads: 4
 mariadb_galera_gcache_size: 250M
-mysql_wsrep_sst_method: xtrabackup_v2
+mysql_wsrep_sst_method: xtrabackup
 mysql_custom_vars: []
 #    - { section: ''          ,name: ''                         ,value: ''                       ,comment: '' }
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -66,6 +66,7 @@ mariadb_misc_config_files: |
     - { src: "mariadb@.service", dest: "/etc/systemd/system/mariadb@.service" }
     {%if mariadb_nrpe|bool %} - \{ src: "nrpe-mariadb.cfg.j2", dest: "/etc/nrpe.d/role-mariadb.cfg", owner: "nrpe", group: "nrpe", mode: "0440" \}{% endif %}
 
+mysql_socket: /var/run/mysqld/mysql.sock
 mysql_max_connections: 500
 mysql_max_user_connections: 200
 mysql_thread_cache_size: 500

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -66,8 +66,16 @@ mariadb_misc_config_files: |
     - { src: "mariadb@.service", dest: "/etc/systemd/system/mariadb@.service" }
     {%if mariadb_nrpe|bool %} - \{ src: "nrpe-mariadb.cfg.j2", dest: "/etc/nrpe.d/role-mariadb.cfg", owner: "nrpe", group: "nrpe", mode: "0440" \}{% endif %}
 
+mysql_max_connections: 500
+mysql_max_user_connections: 200
+mysql_thread_cache_size: 500
+mysql_table_definition_cache: 200
+mysql_table_open_cache: 400
 mysql_collation_server: utf8_general_ci
 mysql_character_set_server: utf8
+mysql_wsrep_slave_threads: 4
+mariadb_galera_gcache_size: 250M
+mysql_wsrep_sst_method: xtrabackup_v2
 mysql_custom_vars: []
 #    - { section: ''          ,name: ''                         ,value: ''                       ,comment: '' }
 

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -84,7 +84,6 @@
     - { name: 'wsrep_load_data_splitting' ,value: 'OFF'                                          ,comment: 'standard:ON but LOAD DATA commands split into transactions of 10000. In case of an error data are partly committed, that`s a mess!' }
     - { name: 'query_cache_size'         ,value: '0'                      ,comment: 'Always disable query_cache on galera nodes!' }
     - { name: 'query_cache_type'         ,value: 'OFF'                    ,comment: 'Always disable query_cache on galera nodes!' }
-    - { name: 'have_query_cache'         ,value: 'OFF'                    ,comment: 'Always disable query_cache on galera nodes!' }
 
 - name: roles:mariadb-galera | tasks | galera-mariadb-my-cnf | 06_custom_vars.cnf
   ini_file:    

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -18,7 +18,6 @@
     value:     "{{ item.value }}"
   register: file_mysql_config_changed
   loop:
-    - { name: 'no_auto_rehash'           ,value: ''                       ,comment: '' }
     - { name: 'max_allowed_packet'       ,value: '16M'                    ,comment: '' }
     - { name: 'prompt'                   ,value: '"\u@\h [\d]> "'         ,comment: 'user@host [schema]> ' }
 

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -8,7 +8,7 @@
   register: file_client_config_changed
   loop:
     - { name: 'port'                     ,value: '3306'                   ,comment: '' }
-    - { name: 'socket'                   ,value: '/var/run/mysqld/mysql.sock' ,comment: '' }
+    - { name: 'socket'                   ,value: '{{ mysql_socket }}'     ,comment: '' }
 
 - name: roles:mariadb-galera | tasks | galera-mariadb-my-cnf | 02_mysql.cnf
   ini_file:    
@@ -20,6 +20,7 @@
   loop:
     - { name: 'max_allowed_packet'       ,value: '16M'                    ,comment: '' }
     - { name: 'prompt'                   ,value: '"\u@\h [\d]> "'         ,comment: 'user@host [schema]> ' }
+    - { name: 'socket'                   ,value: '{{ mysql_socket }}'     ,comment: '' }
 
 - name: roles:mariadb-galera | tasks | galera-mariadb-my-cnf | 03_mysqldump.cnf
   ini_file:    
@@ -52,7 +53,7 @@
   register: file_mysqld_config_changed
   loop:
     - { name: 'port'                     ,value: '3306'                   ,comment: '' }
-    - { name: 'socket'                   ,value: '/var/run/mysqld/mysql.sock' ,comment: '' }
+    - { name: 'socket'                   ,value: '{{ mysql_socket }}'     ,comment: '' }
     - { name: 'max_allowed_packet'       ,value: '16M'                    ,comment: '' }
     - { name: 'default_storage_engine'   ,value: 'InnoDB'                 ,comment: '' }
     - { name: 'character_set_server'     ,value: '{{ mysql_character_set_server }}'              ,comment: '' }

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -43,6 +43,7 @@
     - { name: 'open_files_limit'         ,value: '8192'                   ,comment: 'You possibly have to adapt your O/S settings as well' }
     - { name: 'user'                     ,value: 'mysql'                  ,comment: '' }
     - { name: 'log-error'                ,value: '{{ ansible_hostname }}_error.log'  ,comment: '' }
+    - { name: 'socket'                   ,value: '{{ mysql_socket }}'     ,comment: '' }
 
 - name: roles:mariadb-galera | tasks | galera-mariadb-my-cnf | 05_mysqld.cnf
   ini_file:    

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -8,7 +8,7 @@
   register: file_client_config_changed
   loop:
     - { name: 'port'                     ,value: '3306'                   ,comment: '' }
-    - { name: 'socket'                   ,value: '/var/run/mysqld/mysql.sock' coment: '' }
+    - { name: 'socket'                   ,value: '/var/run/mysqld/mysql.sock' ,comment: '' }
 
 - name: roles:mariadb-galera | tasks | galera-mariadb-my-cnf | 02_mysql.cnf
   ini_file:    
@@ -20,7 +20,7 @@
   loop:
     - { name: 'no_auto_rehash'           ,value: ''                       ,comment: '' }
     - { name: 'max_allowed_packet'       ,value: '16M'                    ,comment: '' }
-    - { name: 'prompt'                   ,value: '\'\u@\h [\d]> \''       ,comment: 'user@host [schema]> ' }
+    - { name: 'prompt'                   ,value: '"\u@\h [\d]> "'         ,comment: 'user@host [schema]> ' }
     - { name: 'default_character_set'    ,value: 'utf8'                   ,comment: 'Possibly this setting is correct for most recent Linux systems' }
 
 - name: roles:mariadb-galera | tasks | galera-mariadb-my-cnf | 03_mysqldump.cnf

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -57,6 +57,7 @@
     - { name: 'socket'                   ,value: '{{ mysql_socket }}'     ,comment: '' }
     - { name: 'max_allowed_packet'       ,value: '16M'                    ,comment: '' }
     - { name: 'default_storage_engine'   ,value: 'InnoDB'                 ,comment: '' }
+    - { name: 'binlog_format'            ,value: 'ROW'                    ,comment: '' }
     - { name: 'character_set_server'     ,value: '{{ mysql_character_set_server }}'              ,comment: '' }
     - { name: 'collation_server'         ,value: '{{ mysql_collation_server }}'                  ,comment: '' }
     - { name: 'log-error'                ,value: '{{ ansible_hostname }}_error.log'              ,comment: '' }
@@ -75,7 +76,13 @@
   register: file_galera_config_changed
   when: galera_wsrep_cluster_name != ""
   loop:
-    - { name: 'log_slave_updates'        ,value: '1'                      ,comment: 'The variable log_slave_updates MUST to be enabled on ALL nodes, otherwise, the option wsrep_received_bytes will not be reflected on the binary logs, thus will lead to WRONG calculations!!' }
+    - { name: 'wsrep_on'                 ,value: 'ON'                                            ,comment: '' }
+    - { name: 'wsrep_provider'           ,value: '/usr/lib/galera/libgalera_smm.so'              ,comment: '' }
+    - { name: 'wsrep_cluster_name'       ,value: '{{ galera_wsrep_cluster_name }}'               ,comment: '' }
+    - { name: 'wsrep_cluster_address'    ,value: '{{ galera_wsrep_cluster_address }}'            ,comment: '' }
+    - { name: 'wsrep_node_name'          ,value: '{{ galera_wsrep_node_name }}'                  ,comment: '' }
+    - { name: 'wsrep_node_address'       ,value: '{{ galera_wsrep_node_address }}'               ,comment: '' }
+    - { name: 'log_slave_updates'        ,value: '1'                                             ,comment: 'The variable log_slave_updates MUST to be enabled on ALL nodes, otherwise, the option wsrep_received_bytes will not be reflected on the binary logs, thus will lead to WRONG calculations!!' }
     - { name: 'wsrep_slave_threads'      ,value: '{{ mysql_wsrep_slave_threads }}'               ,comment: '4 - 8 per core, not more than wsrep_cert_deps_distance' }
     - { name: 'wsrep_provider_options'   ,value: 'gcache.size={{ mariadb_galera_gcache_size }}'  ,comment: 'RingBuffer file size (hdd) for temporary storage of replicated transactions. If your node comes online and cache size is big enough, galera uses IST instead of SST which is MUCH faster!' }
     - { name: 'wsrep_sst_method'         ,value: '{{ mysql_wsrep_sst_method }}'                  ,comment: '' }

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -1,0 +1,97 @@
+---
+- name: roles:mariadb-galera | tasks | galera-mariadb-my-cnf | client.cnf
+  ini_file:    
+    path:      "{{ mariadb_conf_dir }}/01_client.cnf"
+    section:   client
+    option:    "{{ item.name }}"
+    value:     "{{ item.value }}"
+  register: file_client_config_changed
+  loop:
+    - { name: 'port'                     ,value: '3306'                   ,comment: '' }
+    - { name: 'socket'                   ,value: '/var/run/mysqld/mysql.sock' coment: '' }
+
+- name: roles:mariadb-galera | tasks | galera-mariadb-my-cnf | 02_mysql.cnf
+  ini_file:    
+    path:      "{{ mariadb_conf_dir }}/02_mysql.cnf"
+    section:   mysql
+    option:    "{{ item.name }}"
+    value:     "{{ item.value }}"
+  register: file_mysql_config_changed
+  loop:
+    - { name: 'no_auto_rehash'           ,value: ''                       ,comment: '' }
+    - { name: 'max_allowed_packet'       ,value: '16M'                    ,comment: '' }
+    - { name: 'prompt'                   ,value: '\'\u@\h [\d]> \''       ,comment: 'user@host [schema]> ' }
+    - { name: 'default_character_set'    ,value: 'utf8'                   ,comment: 'Possibly this setting is correct for most recent Linux systems' }
+
+- name: roles:mariadb-galera | tasks | galera-mariadb-my-cnf | 03_mysqldump.cnf
+  ini_file:    
+    path:      "{{ mariadb_conf_dir }}/03_mysqldump.cnf"
+    section:   mysqldump
+    option:    "{{ item.name }}"
+    value:     "{{ item.value }}"
+  register: file_mysqldump_config_changed
+  loop:
+    - { name: 'max_allowed_packet'       ,value: '16M'                    ,comment: '' }
+
+- name: roles:mariadb-galera | tasks | galera-mariadb-my-cnf | 04_mysqld_safe.cnf
+  ini_file:    
+    path:      "{{ mariadb_conf_dir }}/04_mysqld_safe.cnf"
+    section:   mysqld_safe
+    option:    "{{ item.name }}"
+    value:     "{{ item.value }}"
+  register: file_mysqld_safe_config_changed
+  loop:
+    - { name: 'open_files_limit'         ,value: '8192'                   ,comment: 'You possibly have to adapt your O/S settings as well' }
+    - { name: 'user'                     ,value: 'mysql'                  ,comment: '' }
+    - { name: 'log-error'                ,value: '{{ ansible_hostname }}_error.log'  ,comment: '' }
+
+- name: roles:mariadb-galera | tasks | galera-mariadb-my-cnf | 05_mysqld.cnf
+  ini_file:    
+    path:      "{{ mariadb_conf_dir }}/05_mysqld.cnf"
+    section:   mysqld
+    option:    "{{ item.name }}"
+    value:     "{{ item.value }}"
+  register: file_mysqld_config_changed
+  loop:
+    - { name: 'port'                     ,value: '3306'                   ,comment: '' }
+    - { name: 'socket'                   ,value: '/var/run/mysqld/mysql.sock' ,comment: '' }
+    - { name: 'max_allowed_packet'       ,value: '16M'                    ,comment: '' }
+    - { name: 'default_storage_engine'   ,value: 'InnoDB'                 ,comment: '' }
+    - { name: 'character_set_server'     ,value: '{{ mysql_character_set_server }}'              ,comment: '' }
+    - { name: 'collation_server'         ,value: '{{ mysql_collation_server }}'                  ,comment: '' }
+    - { name: 'log-error'                ,value: '{{ ansible_hostname }}_error.log'              ,comment: '' }
+    - { name: 'max_connections'          ,value: '{{ mysql_max_connections }}'                   ,comment: 'Values < 1000 are typically good' }
+    - { name: 'max_user_connections'     ,value: '{{ mysql_max_user_connections }}'              ,comment: 'Limit one specific user/application' }
+    - { name: 'thread_cache_size'        ,value: '{{ mysql_thread_cache_size }}'                 ,comment: 'Up to max_connections makes sense' }
+    - { name: 'table_definition_cache'   ,value: '{{ mysql_table_definition_cache }}'            ,comment: 'As big as many tables you have' }
+    - { name: 'table_open_cache'         ,value: '{{ mysql_table_open_cache }}'                  ,comment: 'connections x tables/connection (~2)' }
+
+- name: roles:mariadb-galera | tasks | galera-mariadb-my-cnf | configuration of galera specific variables
+  ini_file:    
+    path:      "{{ mariadb_conf_dir }}/05_mysqld.cnf"
+    section:   mysqld
+    option:    "{{ item.name }}"
+    value:     "{{ item.value }}"
+  register: file_galera_config_changed
+  when: galera_wsrep_cluster_name != ""
+  loop:
+    - { name: 'log_slave_updates'        ,value: '1'                      ,comment: 'The variable log_slave_updates MUST to be enabled on ALL nodes, otherwise, the option wsrep_received_bytes will not be reflected on the binary logs, thus will lead to WRONG calculations!!' }
+    - { name: 'wsrep_slave_threads'      ,value: '{{ mysql_wsrep_slave_threads }}'               ,comment: '4 - 8 per core, not more than wsrep_cert_deps_distance' }
+    - { name: 'wsrep_provider_options'   ,value: 'gcache.size={{ mariadb_galera_gcache_size }}'  ,comment: 'RingBuffer file size (hdd) for temporary storage of replicated transactions. If your node comes online and cache size is big enough, galera uses IST instead of SST which is MUCH faster!' }
+    - { name: 'wsrep_sst_method'         ,value: '{{ mysql_wsrep_sst_method }}'                  ,comment: '' }
+    - { name: 'wsrep_retry_autocommit'   ,value: '5'                                             ,comment: 'Retry N times on deadlock before return and raise deadlock error. !! NOT SAFE FOR multi-statement TRANSACTIONS!!' }
+    - { name: 'wsrep_log_conflicts'      ,value: 'ON'                                            ,comment: 'each Cluster Conflict will be logged into MySQL Error Log' }
+    - { name: 'wsrep_load_data_splitting' ,value: 'OFF'                                          ,comment: 'standard:ON but LOAD DATA commands split into transactions of 10000. In case of an error data are partly committed, that`s a mess!' }
+    - { name: 'query_cache_size'         ,value: '0'                      ,comment: 'Always disable query_cache on galera nodes!' }
+    - { name: 'query_cache_type'         ,value: 'OFF'                    ,comment: 'Always disable query_cache on galera nodes!' }
+    - { name: 'have_query_cache'         ,value: 'OFF'                    ,comment: 'Always disable query_cache on galera nodes!' }
+
+- name: roles:mariadb-galera | tasks | galera-mariadb-my-cnf | 06_custom_vars.cnf
+  ini_file:    
+    path:      "{{ mariadb_conf_dir }}/06_custom_vars.cnf"
+    section:   "{{ item.section }}"
+    option:    "{{ item.name }}"
+    value:     "{{ item.value }}"
+  loop:        "{{ mysql_custom_vars }}"
+  register: file_custom_vars_changed
+  when: mysql_custom_vars is defined and mysql_custom_vars != []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,7 +28,7 @@
 
 - name: delete mysql default location if exists
   file:
-    path: {{ mysql_std_path }}
+    path: "{{ mysql_std_path }}"
     state: absent
   failed_when: False
   when: mysql_mount is defined and mysql_mount|is_mount and not mysql_std_path|is_link

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,14 +27,14 @@
   meta: flush_handlers
 
 - name: Install MariaDB Server (debian/ubuntu)
-  apt: name={{item}} state=installed
+  apt: name={{item}} state=present
   with_items: "{{ mariadb_apt_packages | from_yaml }}"
   when: ansible_os_family == 'Debian'
   tags:
     - apt_pkg
 
 - name: Install MariaDB Server (centos/redhat)
-  yum: name={{item}} state=installed
+  yum: name={{item}} state=present
   with_items:
     - mariadb-server
     - mariadb

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -165,7 +165,7 @@
     executable: /bin/bash
   register: galera_quorum_size
   changed_when: false
-  when: service_mysql_status.rc != 0
+  when: service_mysql_status.rc == 0
 
 - name: get database cluster status for this node
   shell: "mysql <<< \"SHOW STATUS LIKE 'wsrep_cluster_status';\" | awk '{print $2}'| tail -n 1"
@@ -173,7 +173,7 @@
     executable: /bin/bash
   register: galera_wsrep_cluster_status
   changed_when: false
-  when: service_mysql_status.rc != 0
+  when: service_mysql_status.rc == 0
 
 - name: get database cluster size for this node
   shell: "mysql <<< \"SHOW STATUS LIKE 'wsrep_cluster_size';\" | awk '{print $2}'| tail -n 1"
@@ -181,12 +181,12 @@
     executable: /bin/bash
   register: galera_wsrep_cluster_size
   changed_when: false
-  when: service_mysql_status.rc != 0
+  when: service_mysql_status.rc == 0
 
 - debug:
     msg: galera_wsrep_cluster_status={{ galera_wsrep_cluster_status }} galera_wsrep_cluster_size={{ galera_wsrep_cluster_size }}
   when: debug is defined and (debug|bool)
-        and service_mysql_status.rc == 0
+        and service_mysql_status.rc != 0
 
 - name: stop mariadb if config changed (warning! this can take from one second to several hours according to your cluster)
   service: name=mariadb state=stopped

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -58,6 +58,8 @@
   register: misc_config_changed
 
 - name: configuration has changed
+  shell: echo register variable
+  changed_when: false
   register: mysql_config_changed
   when: file_custom_vars_changed.changed or file_mysql_config_changed.changed or
         file_mysqldump_config_changed.changed or file_mysqld_config_changed.changed or
@@ -151,32 +153,46 @@
     - selinux
     - sepermissive
 
+- name: Check if MariaDB is running
+  shell: ps aux | grep mysql | grep -v grep
+  ignore_errors: yes
+  changed_when: false
+  register: service_mysql_status
+
 - name: get database quorum size ( (cluster number of incoming addresses / 2) +1 )
   shell: "echo $((($(mysql <<< \"SHOW STATUS LIKE 'wsrep_incoming_addresses';\" | awk '{print $2}' | tail -n 1 | sed \"s/,/ /\"g |wc -w)/2)+1))"
   args: 
     executable: /bin/bash
   register: galera_quorum_size
+  changed_when: false
+  when: service_mysql_status.rc != 0
 
 - name: get database cluster status for this node
   shell: "mysql <<< \"SHOW STATUS LIKE 'wsrep_cluster_status';\" | awk '{print $2}'| tail -n 1"
   args: 
     executable: /bin/bash
   register: galera_wsrep_cluster_status
+  changed_when: false
+  when: service_mysql_status.rc != 0
 
 - name: get database cluster size for this node
   shell: "mysql <<< \"SHOW STATUS LIKE 'wsrep_cluster_size';\" | awk '{print $2}'| tail -n 1"
   args: 
     executable: /bin/bash
   register: galera_wsrep_cluster_size
+  changed_when: false
+  when: service_mysql_status.rc != 0
 
 - debug:
     msg: galera_wsrep_cluster_status={{ galera_wsrep_cluster_status }} galera_wsrep_cluster_size={{ galera_wsrep_cluster_size }}
   when: debug is defined and (debug|bool)
+        and service_mysql_status.rc == 0
 
 - name: stop mariadb if config changed (warning! this can take from one second to several hours according to your cluster)
   service: name=mariadb state=stopped
   when: mysql_config_changed.changed and
         galera_wsrep_cluster_status.stdout|lower == "primary" and galera_wsrep_cluster_size.stdout|int > galera_quorum_size.stdout|int
+        and service_mysql_status.rc == 0
 
 - name: test if first node does normal start
   service:  name=mariadb state=started

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,7 +38,7 @@
     src: "{{ mysql_mount }}/mysql"
     dest: "{{ mysql_std_path }}"
     state: link
-  when: mysql_std_path is defined and mysql_std_path|is_mount
+  when: mysql_std_path is defined and mysql_std_path != "" and mysql_mount|is_mount
 
 - name: Install MariaDB Server (debian/ubuntu)
   apt: name={{item}} state=present

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,13 +31,6 @@
     path: "{{ mysql_std_path }}"
     state: absent
   failed_when: False
-  when: mysql_mount is defined and mysql_mount|is_mount and not mysql_std_path|is_link
-
-- name: create symlink to mountpoint
-  file:
-    src: "{{ mysql_mount }}/mysql"
-    dest: "{{ mysql_std_path }}"
-    state: link
   when: mysql_mount is defined and mysql_mount is is_mount and not mysql_std_path is is_link
 
 - name: create symlink to mountpoint
@@ -46,6 +39,13 @@
     state: directory
   register: mysql_symlink
   when: mysql_mount is defined and mysql_mount is is_mount
+
+- name: create symlink to mountpoint
+  file:
+    src: "{{ mysql_mount }}/mysql"
+    dest: "{{ mysql_std_path }}"
+    state: link
+  when: mysql_mount is defined and mysql_mount is is_mount and not mysql_std_path is is_link
 
 - name: change permissions for newly created directory
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,27 +26,28 @@
 - name: Flush handlers
   meta: flush_handlers
 
-- name: delete mysql default location if exists
+- name: delete mysql default location {{ mysql_std_path }} if exists
   file:
     path: "{{ mysql_std_path }}"
     state: absent
   failed_when: False
   when: mysql_mount is defined and mysql_mount is is_mount and not mysql_std_path is is_link
 
-- name: create symlink to mountpoint
+- name: create symlink target directory at mountpoint {{ mysql_mount }}
   file:
     path: "{{ mysql_mount }}/mysql"
     state: directory
   register: mysql_symlink
   when: mysql_mount is defined and mysql_mount is is_mount
 
-- name: create symlink to mountpoint
+- name: create symlink {{ mysql_mount }}/mysql to mountpoint {{ mysql_std_path }}
   file:
     src: "{{ mysql_mount }}/mysql"
     dest: "{{ mysql_std_path }}"
     state: link
   when: mysql_mount is defined and mysql_mount is is_mount and not mysql_std_path is is_link
 
+## permission is 0660 for user mysql:mysql but user mysql only exists after packet installation. So we need a temporary permission with access for everyone as dirty hack
 - name: change permissions for newly created directory
   file:
     path: "{{ mysql_mount }}/mysql"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -194,9 +194,8 @@
 - name: stop mariadb if config changed (warning! this can take from one second to several hours according to your cluster)
   service: name=mariadb state=stopped
   when: mysql_config_changed.changed and
-        not galera_wsrep_cluster_status.skipped and not galera_wsrep_cluster_size.skipped and not galera_quorum_size.skipped and
+        service_mysql_status.rc == 0 and
         galera_wsrep_cluster_status.stdout|lower == "primary" and galera_wsrep_cluster_size.stdout|int > galera_quorum_size.stdout|int
-        and service_mysql_status.rc == 0
 
 - name: test if first node does normal start
   service:  name=mariadb state=started

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -57,20 +57,17 @@
   when: mysql_symlink.changed
 
 - name: Install MariaDB Server (debian/ubuntu)
-  apt: name={{item}} state=present
-  with_items: "{{ mariadb_apt_packages | from_yaml }}"
+  package:
+    name: "{{ mariadb_apt_packages | from_yaml }}"
+    state: present
   when: ansible_os_family == 'Debian'
   tags:
     - apt_pkg
 
 - name: Install MariaDB Server (centos/redhat)
-  yum: name={{item}} state=present
-  with_items:
-    - mariadb-server
-    - mariadb
-    - galera
-    - "{% if mariadb_install_xtrabackup|bool %} percona-xtrabackup {% endif %}"
-    - "{% if mariadb_install_backupninja|bool %} backupninja {% endif %}"
+  package:
+    name: "{{ mariadb_yum_packages | from_yaml }}"
+    state: present
   when: ansible_os_family == 'RedHat'
   tags:
     - yum_pkg

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,6 +26,20 @@
 - name: Flush handlers
   meta: flush_handlers
 
+- name: delete mysql default location if exists
+  file:
+    path: {{ mysql_std_path }}
+    state: absent
+  failed_when: False
+  when: mysql_mount is defined and mysql_mount|is_mount and not mysql_std_path|is_link
+
+- name: create symlink to mountpoint
+  file:
+    src: "{{ mysql_mount }}/mysql"
+    dest: "{{ mysql_std_path }}"
+    state: link
+  when: mysql_std_path is defined and mysql_std_path|is_mount
+
 - name: Install MariaDB Server (debian/ubuntu)
   apt: name={{item}} state=present
   with_items: "{{ mariadb_apt_packages | from_yaml }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -53,6 +53,7 @@
   tags:
     - galera
     - template
+  register: galera_config_changed
 
 - name: Template misc mariadb config files
   template: src="{{item.src}}" dest="{{item.dest}}" owner="{{item.owner|default('root')}}" group="{{item.group|default('root')}}" mode="{{item.mode|default('0600')}}"
@@ -61,6 +62,7 @@
     - ssl_cnf
     - mysql-tuning
     - template
+  register: misc_config_changed
 
 - name: Template mariadb nrpe config
   template: src="{{item.src}}" dest="{{item.dest}}" owner="{{item.owner|default('root')}}" group="{{item.group|default('root')}}" mode="{{item.mode|default('0600')}}"
@@ -149,3 +151,44 @@
   tags:
     - selinux
     - sepermissive
+
+- name: stop mariadb if config changed (warning! this can take from one second to several hours according to your cluster)
+  service: name=mariadb state=stopped
+  when: galera_config_changed.changed or misc_config_changed.changed
+
+- name: test if first node does normal start
+  service:  name=mariadb state=started
+  when: 
+        ((galera_current_node_name is defined and galera_current_node_name == (galera_cluster_nodes|from_yaml)[0] ) or
+        ( ansible_hostname == (galera_cluster_nodes|from_yaml)[0] )) and
+        ( galera_config_changed.changed or misc_config_changed.changed )
+  register: firstnode_start_test
+  ignore_errors: true
+
+- debug: 
+    msg: |
+         firstnode_start_test={{ firstnode_start_test }} 
+         galera_cluster_nodes[0]={{ (galera_cluster_nodes| from_yaml)[0] }}
+         galera_config_changed.changed={{ galera_config_changed.changed }}
+         misc_config_changed.changed={{ misc_config_changed.changed }}
+         galera_current_node_name={{ galera_current_node_name }}
+  when: debug is defined and (debug|bool)
+
+- name: test if first node does initial start
+  command: "/usr/bin/galera_new_cluster"
+  become: true
+  when: 
+        ((galera_current_node_name is defined and galera_current_node_name == (galera_cluster_nodes|from_yaml)[0] ) or
+        ( ansible_hostname == (galera_cluster_nodes|from_yaml)[0] )) and
+        ( galera_config_changed.changed or misc_config_changed.changed ) and
+        (firstnode_start_test.failed|bool)
+  ignore_errors: true
+  register: firstnode_initial_start_test
+
+- name: start non_initial nodes
+  service:  name=mariadb state=started
+  when:
+        ((galera_current_node_name is defined and galera_current_node_name != (galera_cluster_nodes|from_yaml)[0] ) or
+        ( ansible_hostname != (galera_cluster_nodes|from_yaml)[0] )) and
+        ( galera_config_changed.changed or misc_config_changed.changed )
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,11 +56,7 @@
 
 - name: Template misc mariadb config files
   template: src="{{item.src}}" dest="{{item.dest}}" owner="{{item.owner|default('root')}}" group="{{item.group|default('root')}}" mode="{{item.mode|default('0600')}}"
-  with_items:
-    - { src: "ssl.cnf.j2", dest: "{{mariadb_conf_dir}}/ssl", mode: "0644" }
-    - { src: "tuning.cnf.j2", dest: "{{mariadb_conf_dir}}/tuning.cnf", mode: "0644" }
-    - { src: "mariadb@.service", dest: "/etc/systemd/system/mariadb@.service" }
-    - { src: "nrpe-mariadb.cfg.j2", dest: "/etc/nrpe.d/role-mariadb.cfg", owner: "nrpe", group: "nrpe", mode: "0440" }
+  with_items: "{{ mariadb_misc_config_files | from_yaml }}"
   tags:
     - ssl_cnf
     - mysql-tuning

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -186,7 +186,7 @@
 - debug:
     msg: galera_wsrep_cluster_status={{ galera_wsrep_cluster_status }} galera_wsrep_cluster_size={{ galera_wsrep_cluster_size }}
   when: debug is defined and (debug|bool)
-        and service_mysql_status.rc != 0
+        and service_mysql_status.rc == 0
 
 - name: stop mariadb if config changed (warning! this can take from one second to several hours according to your cluster)
   service: name=mariadb state=stopped

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -152,6 +152,19 @@
     - selinux
     - sepermissive
 
+- name: get database cluster status for this node
+  shell: "mysql <<< \"SHOW STATUS LIKE 'wsrep_cluster_status';\""
+  args: executable=/bin/bash
+  register: galera_wsrep_cluster_status
+
+- name: get database cluster size for this node
+  shell: "mysql <<< \"SHOW STATUS LIKE 'wsrep_cluster_size';\""
+  args: executable=/bin/bash
+  register: galera_wsrep_cluster_size
+
+- debug:
+    msg: galera_wsrep_cluster_status={{ galera_wsrep_cluster_status }} galera_wsrep_cluster_size={{ galera_wsrep_cluster_size }}
+
 - name: stop mariadb if config changed (warning! this can take from one second to several hours according to your cluster)
   service: name=mariadb state=stopped
   when: galera_config_changed.changed or misc_config_changed.changed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,16 +45,9 @@
   tags:
     - yum_pkg
 
-- name: Template galera config file (when in a galera cluster)
-  template: src="{{item.src}}" dest="{{item.dest}}" owner="{{item.owner|default('root')}}" group="{{item.group|default('root')}}" mode="{{item.mode|default('0600')}}"
-  with_items:
-    - { src: "galera.cnf.j2", dest: "{{mariadb_conf_dir}}/galera.cnf", mode: "0644" }
-  when: galera_wsrep_cluster_name != ""
-  tags:
-    - galera
-    - template
-  register: galera_config_changed
-
+- name: Create config files
+  include: configuration.yml
+  
 - name: Template misc mariadb config files
   template: src="{{item.src}}" dest="{{item.dest}}" owner="{{item.owner|default('root')}}" group="{{item.group|default('root')}}" mode="{{item.mode|default('0600')}}"
   with_items: "{{ mariadb_misc_config_files | from_yaml }}"
@@ -63,6 +56,12 @@
     - mysql-tuning
     - template
   register: misc_config_changed
+
+- name: configuration has changed
+  register: mysql_config_changed
+  when: file_custom_vars_changed.changed or file_mysql_config_changed.changed or
+        file_mysqldump_config_changed.changed or file_mysqld_config_changed.changed or
+        file_mysqld_safe_config_changed.changed or file_galera_config_changed.changed
 
 - name: Template mariadb nrpe config
   template: src="{{item.src}}" dest="{{item.dest}}" owner="{{item.owner|default('root')}}" group="{{item.group|default('root')}}" mode="{{item.mode|default('0600')}}"
@@ -176,15 +175,15 @@
 
 - name: stop mariadb if config changed (warning! this can take from one second to several hours according to your cluster)
   service: name=mariadb state=stopped
-  when: (galera_config_changed.changed or misc_config_changed.changed) and
-         galera_wsrep_cluster_status.stdout|lower == "primary" and galera_wsrep_cluster_size.stdout|int > galera_quorum_size.stdout|int
+  when: mysql_config_changed.changed and
+        galera_wsrep_cluster_status.stdout|lower == "primary" and galera_wsrep_cluster_size.stdout|int > galera_quorum_size.stdout|int
 
 - name: test if first node does normal start
   service:  name=mariadb state=started
   when: 
         ((galera_current_node_name is defined and galera_current_node_name == (galera_cluster_nodes|from_yaml)[0] ) or
         ( ansible_hostname == (galera_cluster_nodes|from_yaml)[0] )) and
-        ( galera_config_changed.changed or misc_config_changed.changed )
+        mysql_config_changed.changed
   register: firstnode_start_test
   ignore_errors: true
 
@@ -192,8 +191,7 @@
     msg: |
          firstnode_start_test={{ firstnode_start_test }} 
          galera_cluster_nodes[0]={{ (galera_cluster_nodes| from_yaml)[0] }}
-         galera_config_changed.changed={{ galera_config_changed.changed }}
-         misc_config_changed.changed={{ misc_config_changed.changed }}
+         mysql_config_changed.changed={{ mysql_config_changed.changed }}
          galera_current_node_name={{ galera_current_node_name }}
   when: debug is defined and (debug|bool)
 
@@ -203,7 +201,7 @@
   when: 
         ((galera_current_node_name is defined and galera_current_node_name == (galera_cluster_nodes|from_yaml)[0] ) or
         ( ansible_hostname == (galera_cluster_nodes|from_yaml)[0] )) and
-        ( galera_config_changed.changed or misc_config_changed.changed ) and
+        mysql_config_changed.changed and
         (firstnode_start_test.failed|bool)
   ignore_errors: true
   register: firstnode_initial_start_test
@@ -213,5 +211,5 @@
   when:
         ((galera_current_node_name is defined and galera_current_node_name != (galera_cluster_nodes|from_yaml)[0] ) or
         ( ansible_hostname != (galera_cluster_nodes|from_yaml)[0] )) and
-        ( galera_config_changed.changed or misc_config_changed.changed )
+        mysql_config_changed.changed
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,7 +38,22 @@
     src: "{{ mysql_mount }}/mysql"
     dest: "{{ mysql_std_path }}"
     state: link
-  when: mysql_std_path is defined and mysql_std_path != "" and mysql_mount|is_mount
+  when: mysql_mount is defined and mysql_mount is is_mount and not mysql_std_path is is_link
+
+- name: create symlink to mountpoint
+  file:
+    path: "{{ mysql_mount }}/mysql"
+    state: directory
+  register: mysql_symlink
+  when: mysql_mount is defined and mysql_mount is is_mount
+
+- name: change permissions for newly created directory
+  file:
+    path: "{{ mysql_mount }}/mysql"
+    state: directory
+    mode: '0777'
+  register: mysql_symlink
+  when: mysql_symlink.changed
 
 - name: Install MariaDB Server (debian/ubuntu)
   apt: name={{item}} state=present
@@ -58,6 +73,16 @@
   when: ansible_os_family == 'RedHat'
   tags:
     - yum_pkg
+
+- name: set symlink destination permissions
+  file:
+    path: "{{ mysql_mount }}/mysql"
+    state: directory
+    owner: mysql
+    group: mysql
+    mode: '0770'
+    recurse: yes
+  when: mysql_mount is defined and mysql_mount is is_mount
 
 - name: Create config files
   include: configuration.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,12 +28,7 @@
 
 - name: Install MariaDB Server (debian/ubuntu)
   apt: name={{item}} state=installed
-  with_items:
-    - mariadb-server-{{mariadb_version}}
-    - mariadb-client-core-{{mariadb_version}}
-    - galera-3
-    - "{% if mariadb_install_xtrabackup|bool %} percona-xtrabackup {% endif %}" # Untested
-    - "{% if mariadb_install_backupninja|bool %} backupninja {% endif %}"
+  with_items: "{{ mariadb_apt_packages | from_yaml }}"
   when: ansible_os_family == 'Debian'
   tags:
     - apt_pkg

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -152,22 +152,32 @@
     - selinux
     - sepermissive
 
+- name: get database quorum size ( (cluster number of incoming addresses / 2) +1 )
+  shell: "echo $((($(mysql <<< \"SHOW STATUS LIKE 'wsrep_incoming_addresses';\" | awk '{print $2}' | tail -n 1 | sed \"s/,/ /\"g |wc -w)/2)+1))"
+  args: 
+    executable: /bin/bash
+  register: galera_quorum_size
+
 - name: get database cluster status for this node
-  shell: "mysql <<< \"SHOW STATUS LIKE 'wsrep_cluster_status';\""
-  args: executable=/bin/bash
+  shell: "mysql <<< \"SHOW STATUS LIKE 'wsrep_cluster_status';\" | awk '{print $2}'| tail -n 1"
+  args: 
+    executable: /bin/bash
   register: galera_wsrep_cluster_status
 
 - name: get database cluster size for this node
-  shell: "mysql <<< \"SHOW STATUS LIKE 'wsrep_cluster_size';\""
-  args: executable=/bin/bash
+  shell: "mysql <<< \"SHOW STATUS LIKE 'wsrep_cluster_size';\" | awk '{print $2}'| tail -n 1"
+  args: 
+    executable: /bin/bash
   register: galera_wsrep_cluster_size
 
 - debug:
     msg: galera_wsrep_cluster_status={{ galera_wsrep_cluster_status }} galera_wsrep_cluster_size={{ galera_wsrep_cluster_size }}
+  when: debug is defined and (debug|bool)
 
 - name: stop mariadb if config changed (warning! this can take from one second to several hours according to your cluster)
   service: name=mariadb state=stopped
-  when: galera_config_changed.changed or misc_config_changed.changed
+  when: (galera_config_changed.changed or misc_config_changed.changed) and
+         galera_wsrep_cluster_status.stdout|lower == "primary" and galera_wsrep_cluster_size.stdout|int > galera_quorum_size.stdout|int
 
 - name: test if first node does normal start
   service:  name=mariadb state=started

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -59,7 +59,6 @@
 
 - name: configuration has changed
   shell: echo register variable
-  changed_when: false
   register: mysql_config_changed
   when: file_custom_vars_changed.changed or file_mysql_config_changed.changed or
         file_mysqldump_config_changed.changed or file_mysqld_config_changed.changed or
@@ -188,9 +187,14 @@
   when: debug is defined and (debug|bool)
         and service_mysql_status.rc == 0
 
+- debug:
+    msg: galera_wsrep_cluster_status={{ galera_wsrep_cluster_status }} galera_wsrep_cluster_size={{ galera_wsrep_cluster_size }} galera_quorum_size={{ galera_quorum_size }}
+  when: debug is defined and (debug|bool)
+
 - name: stop mariadb if config changed (warning! this can take from one second to several hours according to your cluster)
   service: name=mariadb state=stopped
   when: mysql_config_changed.changed and
+        not galera_wsrep_cluster_status.skipped and not galera_wsrep_cluster_size.skipped and not galera_quorum_size.skipped and
         galera_wsrep_cluster_status.stdout|lower == "primary" and galera_wsrep_cluster_size.stdout|int > galera_quorum_size.stdout|int
         and service_mysql_status.rc == 0
 

--- a/tasks/mydumper.yml
+++ b/tasks/mydumper.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Install myloader/mydumper from package
-  package: name={{item}} state=installed
+  package: name={{item}} state=present
   with_items:
     - mydumper
   when: mariadb_install_mydumper_package|bool

--- a/templates/galera.cnf.j2
+++ b/templates/galera.cnf.j2
@@ -23,5 +23,5 @@ wsrep_cluster_address="{{galera_wsrep_cluster_address}}"
 wsrep_sst_method=rsync
 
 # Galera Node Configuration
-wsrep_node_address="{{ansible_default_ipv4.address}}"
+wsrep_node_address="{% if wsrep_node_address is defined %}{{ wsrep_node_address }}{% else %}{{ ansible_default_ipv4.address}}{% endif %}"
 wsrep_node_name="{{ansible_hostname}}"


### PR DESCRIPTION
the following bugs have been fixed:
* (debian/ubuntu) if either xtrabackup or backupninja does not exist apt task will fail
* (all environments) if mariadb_nrpe is false ansible will fail
* (all environments) state=installed is deprecated, switched to installed accourding to ansible's warning message
* added stop-start for galera-node if config changed
* enhanced documentation